### PR TITLE
feat: Add `cached_sign_in_with_password` method to SupabaseConnection for faster, cache-enabled sign-ins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   - id: check-ast
   - id: check-executables-have-shebangs
@@ -11,19 +11,19 @@ repos:
   - id: fix-byte-order-marker
   - id: requirements-txt-fixer
 - repo: https://github.com/pycqa/isort
-  rev: 5.13.2
+  rev: 6.0.1
   hooks:
   - id: isort
     args: [--profile, black]
 - repo: https://github.com/psf/black
-  rev: 24.4.2
+  rev: 25.1.0
   hooks:
   - id: black
     args:
     - --line-length=100
 
 - repo: https://github.com/sourcery-ai/sourcery
-  rev: v1.27.0
+  rev: v1.36.0
   hooks:
   - id: sourcery
     # The best way to use Sourcery in a pre-commit hook:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,41 @@
 # :electric_plug: Streamlit Supabase Connector
-[![Downloads](https://static.pepy.tech/personalized-badge/st-supabase-connection?period=total&units=international_system&left_color=black&right_color=brightgreen&left_text=Downloads)](https://pepy.tech/project/st-supabase-connection)
+<div align="center">
+  <a href="https://pepy.tech/project/st-supabase-connection">
+    <img src="https://static.pepy.tech/personalized-badge/st-supabase-connection?period=total&units=international_system&left_color=black&right_color=brightgreen&left_text=Downloads" alt="Downloads">
+  </a>
+  <a href="https://badge.fury.io/py/st-supabase-connection">
+    <img src="https://badge.fury.io/py/st-supabase-connection.svg" alt="PyPI version">
+  </a>
+  <a href="https://opensource.org/licenses/MIT">
+    <img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT">
+  </a>
+  <a href="https://github.com/SiddhantSadangi/st_supabase_connection/issues">
+    <img src="https://img.shields.io/github/issues/SiddhantSadangi/st_supabase_connection.svg" alt="Issues">
+  </a>
+  <a href="https://github.com/SiddhantSadangi/st_supabase_connection/pulls">
+    <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome">
+  </a>
+</div>
 
 A Streamlit connection component to connect Streamlit to Supabase Storage, Database, and Auth.
+
+## 🚀 Quickstart
+
+```python
+import streamlit as st
+from st_supabase_connection import SupabaseConnection
+
+st_supabase_client = st.connection(
+    name="supabase_connection",
+    type=SupabaseConnection,
+    url=<your-supabase-url>,
+    key=<your-supabase-key>
+)
+
+# Example: List buckets
+buckets = st_supabase_client.list_buckets()
+st.write(buckets)
+```
 
 ## :student: Interactive tutorial
 <div align="center">
@@ -207,7 +241,8 @@ pip install st-supabase-connection
 <details>
 <summary> Auth </summary>
 <ul>
-    All methods supported by <a href="https://supabase.com/docs/reference/python/auth-signup">Supabase's Python API </a>.
+    <li> <code>cached_sign_in_with_password()</code> - Cached version of <code>sign_in_with_password()</code> for faster sign-in. </li>
+    <li> All methods supported by <a href="https://supabase.com/docs/reference/python/auth-signup">Supabase's Python API </a>.
 </details>
 
 ## :books: Examples
@@ -510,23 +545,25 @@ st_supabase_client.auth.sign_up(
 ```
 
 #### Sign in with password
+`SupabaseConnection()` offers a cached version of `sign_in_with_password()` for faster, request-free sign-ins.
+
 ```python
-st_supabase_client.auth.sign_in_with_password(dict(email='test.user@abc.com', password='***'))
+st_supabase_client.cached_sign_in_with_password(dict(email='test.user@abc.com', password='***'))
 ```
 
 #### Retrieve session
 ```python
-st_supabase.auth.get_session()
+st_supabase_client.auth.get_session()
 ```
 
 #### Retrieve user
 ```python
-st_supabase.auth.get_user()
+st_supabase_client.auth.get_user()
 ```
 
 #### Sign out
 ```python
-st_supabase.auth.sign_out()
+st_supabase_client.auth.sign_out()
 ```
 
 > [!NOTE]  
@@ -538,8 +575,18 @@ st_supabase.auth.sign_out()
 ## :bow: Acknowledgements
 This connector builds upon the awesome work done by the open-source community in general and the [Supabase Community](https://github.com/supabase-community) in particular. I cannot be more thankful to all the authors whose work I have used either directly or indirectly.
 
+Thanks to all contributors to this project :bow:
+
+<p align="center">
+    <a href="https://github.com/SiddhantSadangi/st_supabase_connection/graphs/contributors">
+        <img src="https://contrib.rocks/image?repo=SiddhantSadangi/st_supabase_connection" alt="Contributors" style="height: 60px !important;width: 217px !important;">
+    </a>
+</p>
+
 ## :hugs: Want to support my work?
 <p align="center">
-    <a href="https://www.buymeacoffee.com/siddhantsadangi" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;">
+    <a href="https://www.buymeacoffee.com/siddhantsadangi" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;">
     </a>
+    <br>
+    <a href="https://github.com/sponsors/SiddhantSadangi" target="_blank"><img src="https://img.shields.io/badge/Sponsor%20me%20on-GitHub-f34b7d?logo=github&style=flat" alt="Sponsor me on GitHub" style="height: 28px !important;">
 </p>

--- a/demo/app.py
+++ b/demo/app.py
@@ -1034,16 +1034,9 @@ if st.session_state["initialized"]:
                 help="Password is encrypted",
             )
 
-            if "@" in identifier:
-                email = identifier
-                constructed_auth_query = (
-                    f"st_supabase.cached_sign_in_with_password(dict({email=}, {password=}))"
-                )
-            else:
-                phone = identifier
-                constructed_auth_query = (
-                    f"st_supabase.cached_sign_in_with_password(dict({phone=}, {password=}))"
-                )
+            identifier_field = "email" if "@" in identifier else "phone"
+            creds = {identifier_field: identifier, "password": password}
+            constructed_auth_query = f"st_supabase.cached_sign_in_with_password({creds})"
 
         elif auth_operation == "sign_in_with_otp":
             st.info(
@@ -1091,11 +1084,8 @@ st_supabase.auth.verify_otp(dict(type="magiclink", email=email, token=token))
 
                 if auth_operation == "sign_up":
                     auth_success_message = f"User created. Welcome {fname or ''} 🚀"
-                elif auth_operation in "sign_in_with_password":
-                    if "fname" in response.model_dump()["user"]["user_metadata"]:
-                        name = response.model_dump()["user"]["user_metadata"]["fname"]
-                    else:
-                        name = ""
+                elif auth_operation == "sign_in_with_password":
+                    name = response.model_dump()["user"]["user_metadata"].get("fname", "")
                     auth_success_message = f"""Logged in. Welcome {name}  🔓"""
                 elif auth_operation == "sign_out":
                     auth_success_message = "Signed out 🔒"

--- a/demo/app.py
+++ b/demo/app.py
@@ -6,7 +6,10 @@ from st_social_media_links import SocialMediaIcons
 from streamlit.components.v1 import html as st_html
 
 from st_supabase_connection import execute_query  # noqa: F401
-from st_supabase_connection import SupabaseConnection, __version__
+from st_supabase_connection import (
+    SupabaseConnection,
+    __version__,
+)
 
 VERSION = __version__
 
@@ -1023,7 +1026,7 @@ if st.session_state["initialized"]:
 
         elif auth_operation == "sign_in_with_password":
             lcol, rcol = st.columns(2)
-            email = lcol.text_input(label="Enter your email ID")
+            identifier = lcol.text_input(label="Enter your email ID or phone number")
             password = rcol.text_input(
                 label="Enter your password",
                 placeholder="Min 6 characters",
@@ -1031,9 +1034,16 @@ if st.session_state["initialized"]:
                 help="Password is encrypted",
             )
 
-            constructed_auth_query = (
-                f"st_supabase.auth.{auth_operation}(dict({email=}, {password=}))"
-            )
+            if "@" in identifier:
+                email = identifier
+                constructed_auth_query = (
+                    f"st_supabase.cached_sign_in_with_password(dict({email=}, {password=}))"
+                )
+            else:
+                phone = identifier
+                constructed_auth_query = (
+                    f"st_supabase.cached_sign_in_with_password(dict({phone=}, {password=}))"
+                )
 
         elif auth_operation == "sign_in_with_otp":
             st.info(
@@ -1082,7 +1092,11 @@ st_supabase.auth.verify_otp(dict(type="magiclink", email=email, token=token))
                 if auth_operation == "sign_up":
                     auth_success_message = f"User created. Welcome {fname or ''} 🚀"
                 elif auth_operation in "sign_in_with_password":
-                    auth_success_message = f"""Logged in. Welcome {response.dict()["user"]["user_metadata"]["fname"] or ''}  🔓"""
+                    if "fname" in response.model_dump()["user"]["user_metadata"]:
+                        name = response.model_dump()["user"]["user_metadata"]["fname"]
+                    else:
+                        name = ""
+                    auth_success_message = f"""Logged in. Welcome {name}  🔓"""
                 elif auth_operation == "sign_out":
                     auth_success_message = "Signed out 🔒"
                 elif auth_operation == "get_user":
@@ -1104,7 +1118,7 @@ st_supabase.auth.verify_otp(dict(type="magiclink", email=email, token=token))
 
                 if response is not None:
                     with st.expander("JSON response"):
-                        st.write(response.dict())
+                        st.write(response.model_dump())
 
             except Exception as e:
                 if auth_operation == "get_user":

--- a/src/st_supabase_connection/__init__.py
+++ b/src/st_supabase_connection/__init__.py
@@ -307,9 +307,7 @@ class SupabaseConnection(BaseConnection[Client]):
             "file_size_limit": file_size_limit,
             "allowed_mime_types": allowed_mime_types,
         }
-        response = self.client.storage._request(
-            "PUT", f"/bucket/{bucket_id}", json=json
-        )
+        response = self.client.storage._request("PUT", f"/bucket/{bucket_id}", json=json)
         return response.json()
 
     def move(self, bucket_id: str, from_path: str, to_path: str) -> "dict[str, str]":
@@ -358,9 +356,7 @@ class SupabaseConnection(BaseConnection[Client]):
         path: Optional[str] = None,
         limit: int = 100,
         offset: int = 0,
-        sortby: Optional[
-            Literal["name", "updated_at", "created_at", "last_accessed_at"]
-        ] = "name",
+        sortby: Optional[Literal["name", "updated_at", "created_at", "last_accessed_at"]] = "name",
         order: Optional[Literal["asc", "desc"]] = "asc",
         ttl: Optional[Union[float, timedelta, str]] = None,
     ) -> "list[dict[str, str]]":
@@ -530,9 +526,7 @@ class SupabaseConnection(BaseConnection[Client]):
 
 
 def execute_query(
-    query: Union[
-        SyncSelectRequestBuilder, SyncQueryRequestBuilder, SyncFilterRequestBuilder
-    ],
+    query: Union[SyncSelectRequestBuilder, SyncQueryRequestBuilder, SyncFilterRequestBuilder],
     ttl: Optional[Union[float, timedelta, str]] = None,
 ) -> APIResponse:
     """Execute the query.

--- a/src/st_supabase_connection/__init__.py
+++ b/src/st_supabase_connection/__init__.py
@@ -4,8 +4,9 @@ import urllib
 from datetime import timedelta
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Literal, NotRequired, Optional, Tuple, TypedDict, Union
+from typing import Literal, Optional, Tuple, Union
 
+from gotrue.types import SignInWithPasswordCredentials
 from postgrest import (
     APIResponse,
     SyncFilterRequestBuilder,
@@ -16,30 +17,7 @@ from streamlit import cache_data, cache_resource
 from streamlit.connections import BaseConnection
 from supabase import Client, create_client
 
-__version__ = "2.0.1"
-
-
-class SignInWithPasswordCredentialsOptions(TypedDict):
-    data: NotRequired[Any]
-    captcha_token: NotRequired[str]
-
-
-class SignInWithEmailAndPasswordCredentials(TypedDict):
-    email: str
-    password: str
-    options: NotRequired[SignInWithPasswordCredentialsOptions]
-
-
-class SignInWithPhoneAndPasswordCredentials(TypedDict):
-    phone: str
-    password: str
-    options: NotRequired[SignInWithPasswordCredentialsOptions]
-
-
-SignInWithPasswordCredentials = Union[
-    SignInWithEmailAndPasswordCredentials,
-    SignInWithPhoneAndPasswordCredentials,
-]
+__version__ = "2.1.0"
 
 
 class SupabaseConnection(BaseConnection[Client]):

--- a/src/st_supabase_connection/__init__.py
+++ b/src/st_supabase_connection/__init__.py
@@ -6,7 +6,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Literal, Optional, Tuple, Union
 
-from gotrue.types import SignInWithPasswordCredentials
+from gotrue.types import AuthResponse, SignInWithPasswordCredentials
 from postgrest import (
     APIResponse,
     SyncFilterRequestBuilder,
@@ -76,7 +76,7 @@ class SupabaseConnection(BaseConnection[Client]):
         self,
         credentials: SignInWithPasswordCredentials,
         ttl: Optional[Union[float, timedelta, str]] = None,
-    ) -> None:
+    ) -> AuthResponse:
         """Sign in with email and password or phone number and password, with caching enabled.
 
         Parameters
@@ -97,7 +97,7 @@ class SupabaseConnection(BaseConnection[Client]):
         self,
         bucket_id: str,
         ttl: Optional[Union[float, timedelta, str]] = None,
-    ):
+    ) -> dict[str, str]:
         """Retrieves the details of an existing storage bucket.
 
         Parameters
@@ -117,7 +117,7 @@ class SupabaseConnection(BaseConnection[Client]):
     def list_buckets(
         self,
         ttl: Optional[Union[float, timedelta, str]] = None,
-    ) -> list:
+    ) -> list[dict[str, str]]:
         """Retrieves the details of all storage buckets within an existing product.
 
         Parameters

--- a/src/st_supabase_connection/__init__.py
+++ b/src/st_supabase_connection/__init__.py
@@ -99,7 +99,7 @@ class SupabaseConnection(BaseConnection[Client]):
         credentials: SignInWithPasswordCredentials,
         ttl: Optional[Union[float, timedelta, str]] = None,
     ) -> None:
-        """Sign in with email and password.
+        """Sign in with email and password or phone number and password, with caching enabled.
 
         Parameters
         ----------


### PR DESCRIPTION
## Summary by Sourcery

Implement a cache-backed sign-in method with typed credentials, update version and type annotations, enhance the demo app to support email or phone logins, refresh documentation, and bump CI hook versions.

New Features:
- Add cached_sign_in_with_password method to SupabaseConnection for faster, cache-enabled sign-ins

Enhancements:
- Introduce typed credential annotations and explicit return types for bucket methods
- Allow identifier field to accept email or phone with dynamic detection in the demo app
- Bump package version to 2.1.0

CI:
- Upgrade pre-commit hook versions for pre-commit-hooks, isort, black, and sourcery

Documentation:
- Revamp README with multiple badges, Quickstart guide, documentation for cached sign-in, and updated examples