### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish_PYPI_each_tag.yml
+++ b/.github/workflows/publish_PYPI_each_tag.yml
@@ -3,6 +3,8 @@
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: Upload Python Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/SiddhantSadangi/st_supabase_connection/security/code-scanning/4](https://github.com/SiddhantSadangi/st_supabase_connection/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Since the workflow involves checking out the repository and publishing a package to PyPI, it only needs `contents: read` permission. This ensures that the workflow has the least privilege necessary to perform its tasks.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Add a permissions block to the workflow file to grant contents: read permission