### PR TITLE
v2.1.3 (fix): : Fixed path issues while creating signed URLs

### DIFF
--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -37,7 +37,7 @@ rule_settings:
   - refactoring
   - suggestion
   - comment
-  python_version: '3.9' # A string specifying the lowest Python version your project supports. Sourcery will not suggest refactorings requiring a higher Python version.
+  python_version: '3.10' # A string specifying the lowest Python version your project supports. Sourcery will not suggest refactorings requiring a higher Python version.
 
 # rules:  # A list of custom rules Sourcery will include in its analysis.
 # - id: no-print-statements

--- a/demo/app.py
+++ b/demo/app.py
@@ -1,4 +1,5 @@
 import contextlib
+from typing import Any
 
 import pandas as pd
 import streamlit as st
@@ -28,6 +29,29 @@ st.set_page_config(
 
 
 set_global_exception_handler(custom_exception_handler)
+
+
+class CodeLiteral(str):
+    """Marker to indicate a pre-rendered snippet that should not be repr()-ed."""
+
+
+def literal(value: str) -> CodeLiteral:
+    return CodeLiteral(value)
+
+
+def construct_storage_call(operation: str, /, *args: Any, **kwargs: Any) -> str:
+    parts: list[str] = []
+    for value in args:
+        rendered = value if isinstance(value, CodeLiteral) else repr(value)
+        parts.append(rendered)
+    for key, value in kwargs.items():
+        rendered = value if isinstance(value, CodeLiteral) else repr(value)
+        parts.append(f"{key}={rendered}")
+    if not parts:
+        return f"st_supabase.{operation}()"
+    joined = ",\n    ".join(parts)
+    return f"st_supabase.{operation}(\n    {joined},\n)"
+
 
 # ---------- INIT SESSION ----------
 upsert = operators = bucket_id = file_size_limit = allowed_mime_types = source = None
@@ -306,11 +330,11 @@ if st.session_state["initialized"]:
                 help="Leave blank to cache indefinitely",
             )
             ttl = None if ttl == "" else ttl
-            constructed_storage_query = f"""st_supabase.{operation}("{bucket_id}", {ttl=})"""
+            constructed_storage_query = construct_storage_call(operation, bucket_id, ttl=ttl)
             st.session_state["storage_disabled"] = bool(not bucket_id)
 
         elif operation in ["delete_bucket", "empty_bucket"]:
-            constructed_storage_query = f"""st_supabase.{operation}("{bucket_id}")"""
+            constructed_storage_query = construct_storage_call(operation, bucket_id)
             st.session_state["storage_disabled"] = bool(not bucket_id)
 
         elif operation == "create_bucket":
@@ -343,7 +367,17 @@ if st.session_state["initialized"]:
                 value=False,
             )
 
-            constructed_storage_query = f"""st_supabase.create_bucket('{bucket_id}',{name=},{file_size_limit=},allowed_mime_types={allowed_mime_types},{public=})"""
+            allowed_literal = literal(
+                allowed_mime_types if allowed_mime_types is not None else "None"
+            )
+            constructed_storage_query = construct_storage_call(
+                operation,
+                bucket_id,
+                name=name,
+                file_size_limit=file_size_limit,
+                allowed_mime_types=allowed_literal,
+                public=public,
+            )
             st.session_state["storage_disabled"] = bool(not bucket_id)
 
         elif operation == "update_bucket":
@@ -380,7 +414,16 @@ if st.session_state["initialized"]:
                         st.write(e)
                     st.session_state["storage_disabled"] = True
 
-            constructed_storage_query = f"""st_supabase.{operation}('{bucket_id}',{file_size_limit=},allowed_mime_types={allowed_mime_types},{public=})"""
+            allowed_literal = literal(
+                allowed_mime_types if allowed_mime_types is not None else "None"
+            )
+            constructed_storage_query = construct_storage_call(
+                operation,
+                bucket_id,
+                file_size_limit=file_size_limit,
+                allowed_mime_types=allowed_literal,
+                public=public,
+            )
 
         elif operation == "upload":
             destination_path = None
@@ -401,17 +444,16 @@ if st.session_state["initialized"]:
                 )
                 overwrite = "true" if rcol.checkbox("Overwrite if exists?") else "false"
 
-                constructed_storage_query = (
-                    f"""
-st_supabase.{operation}(
-    "{bucket_id}", 
-    {source=}, 
-    file={file}, 
-    destination_path="{destination_path}", 
-    {overwrite=},
-)
-# `UploadedFile` is the `BytesIO` object returned by `st.file_uploader()`
-""",
+                constructed_storage_query = construct_storage_call(
+                    operation,
+                    bucket_id,
+                    source=source,
+                    file=literal("file"),
+                    destination_path=destination_path,
+                    overwrite=overwrite,
+                )
+                constructed_storage_query += (
+                    "\n# `UploadedFile` is the `BytesIO` object returned by `st.file_uploader()`"
                 )
             else:
                 file = rcol.text_input(
@@ -425,15 +467,14 @@ st_supabase.{operation}(
                     value=file,
                 )
                 overwrite = "true" if rcol.checkbox("Overwrite if exists?") else "false"
-                constructed_storage_query = f"""
-st_supabase.{operation}(
-    "{bucket_id}", 
-    {source=}, 
-    {file=}, 
-    destination_path="{destination_path}", 
-    {overwrite=},
-)
-"""
+                constructed_storage_query = construct_storage_call(
+                    operation,
+                    bucket_id,
+                    source=source,
+                    file=file,
+                    destination_path=destination_path,
+                    overwrite=overwrite,
+                )
             st.session_state["storage_disabled"] = bool(not all([bucket_id, file]))
         elif operation == "list_buckets":
             ttl = st.text_input(
@@ -443,7 +484,7 @@ st_supabase.{operation}(
                 help="Leave blank to cache indefinitely",
             )
             ttl = None if ttl == "" else ttl
-            constructed_storage_query = f"""st_supabase.{operation}({ttl=})"""
+            constructed_storage_query = construct_storage_call(operation, ttl=ttl)
             st.session_state["storage_disabled"] = False
 
         elif operation == "download":
@@ -460,13 +501,12 @@ st_supabase.{operation}(
             )
             ttl = None if ttl == "" else ttl
 
-            constructed_storage_query = f"""
-st_supabase.{operation}(
-    "{bucket_id}", 
-    {source_path=}, 
-    {ttl=},
-)
-"""
+            constructed_storage_query = construct_storage_call(
+                operation,
+                bucket_id,
+                source_path=source_path,
+                ttl=ttl,
+            )
             st.session_state["storage_disabled"] = bool(not all([bucket_id, source_path]))
 
         elif operation == "move":
@@ -479,13 +519,12 @@ st_supabase.{operation}(
                 placeholder="/folder/subFolder/file.txt",
                 help="Path will be created if it does not exist",
             )
-            constructed_storage_query = f"""
-st_supabase.{operation}(
-    "{bucket_id}", 
-    {from_path=}, 
-    {to_path=},
-)
-"""
+            constructed_storage_query = construct_storage_call(
+                operation,
+                bucket_id,
+                from_path=from_path,
+                to_path=to_path,
+            )
 
             st.session_state["storage_disabled"] = bool(not all([bucket_id, from_path, to_path]))
         elif operation == "remove":
@@ -494,12 +533,11 @@ st_supabase.{operation}(
                 placeholder="""["image.png","/folder/subFolder/file.txt"]""",
                 help="Enter as a list",
             )
-            constructed_storage_query = f"""
-st_supabase.{operation}(
-    "{bucket_id}", 
-    paths={paths},
-)
-"""
+            constructed_storage_query = construct_storage_call(
+                operation,
+                bucket_id,
+                paths=literal(paths),
+            )
 
             st.session_state["storage_disabled"] = bool(not all([bucket_id, paths]))
         elif operation == "list_objects":
@@ -543,17 +581,16 @@ st_supabase.{operation}(
                 horizontal=True,
             )
 
-            constructed_storage_query = f"""
-st_supabase.{operation}(
-    "{bucket_id}", 
-    {path=}, 
-    {limit=}, 
-    {offset=}, 
-    {sortby=}, 
-    {order=}, 
-    {ttl=},
-)
-"""
+            constructed_storage_query = construct_storage_call(
+                operation,
+                bucket_id,
+                path=path,
+                limit=limit,
+                offset=offset,
+                sortby=sortby,
+                order=order,
+                ttl=ttl,
+            )
 
             st.session_state["storage_disabled"] = not bool(bucket_id)
 
@@ -571,13 +608,12 @@ st_supabase.{operation}(
             )
             ttl = None if ttl == "" else ttl
 
-            constructed_storage_query = f"""
-st_supabase.get_public_url(
-    "{bucket_id}",
-    {filepath=},
-    {ttl=},
-)
-"""
+            constructed_storage_query = construct_storage_call(
+                operation,
+                bucket_id,
+                filepath=filepath,
+                ttl=ttl,
+            )
 
             st.session_state["storage_disabled"] = bool(not all([bucket_id, filepath]))
 
@@ -594,13 +630,12 @@ st_supabase.get_public_url(
                 value=3600,
             )
 
-            constructed_storage_query = f"""
-st_supabase.create_signed_urls(
-    "{bucket_id}",
-    paths={paths},
-    {expires_in=},
-)
-"""
+            constructed_storage_query = construct_storage_call(
+                operation,
+                bucket_id,
+                paths=literal(paths),
+                expires_in=expires_in,
+            )
             st.session_state["storage_disabled"] = bool(not all([bucket_id, paths, expires_in]))
 
         elif operation == "create_signed_upload_url":
@@ -608,12 +643,11 @@ st_supabase.create_signed_urls(
                 "Enter the file path",
                 placeholder="/folder/subFolder/image.jpg",
             )
-            constructed_storage_query = f"""
-st_supabase.create_signed_upload_url(
-    "{bucket_id}",
-    {path=},
-)
-"""
+            constructed_storage_query = construct_storage_call(
+                operation,
+                bucket_id,
+                path=path,
+            )
             st.session_state["storage_disabled"] = bool(not all([bucket_id, path]))
 
         elif operation == "upload_to_signed_url":
@@ -633,38 +667,34 @@ st_supabase.create_signed_upload_url(
                 options=["local", "hosted"],
                 help="Filesystem from where the file has to be uploaded",
             )
-            overwrite = "false"
             if source == "local":
                 file = rcol.file_uploader("Choose a file")
 
-                constructed_storage_query = f"""
-st_supabase.{operation}(
-        "{bucket_id}", 
-        {source=}, 
-        {path=}, 
-        token="***", 
-        file={file}, 
-        {overwrite=},
-)
-# `UploadedFile` is the `BytesIO` object returned by `st.file_uploader()`
-"""
-            elif source == "hosted":
+                constructed_storage_query = construct_storage_call(
+                    operation,
+                    bucket_id,
+                    path=path,
+                    token=literal('"***"'),
+                    file=literal("file"),
+                )
+                constructed_storage_query += (
+                    "\n# `UploadedFile` is the `BytesIO` object returned by `st.file_uploader()`"
+                )
+            else:
                 file = rcol.text_input(
                     "Source path",
                     placeholder="path/to/file.txt",
                     help="This is the path of the file on the Streamlit hosted filesystem",
                 )
-                constructed_storage_query = f"""
-st_supabase.{operation}(
-    "{bucket_id}", 
-    {source=}, 
-    {path=}, 
-    token="***", 
-    {file=}, 
-    {overwrite=},
-)
-"""
-            st.session_state["storage_disabled"] = bool(not all([bucket_id, token, path]))
+                constructed_storage_query = construct_storage_call(
+                    operation,
+                    bucket_id,
+                    path=path,
+                    token=literal('"***"'),
+                    file=file,
+                )
+            required_inputs = [bucket_id, token, path, file]
+            st.session_state["storage_disabled"] = bool(not all(required_inputs))
 
         st.write("**Constructed code**")
         if operation == "download":
@@ -719,7 +749,6 @@ st_supabase.{operation}(
                 elif operation == "upload_to_signed_url":
                     response = st_supabase.upload_to_signed_url(
                         bucket_id,
-                        source,
                         path,
                         token,
                         file,

--- a/demo/app.py
+++ b/demo/app.py
@@ -151,10 +151,10 @@ with st.expander("**Select project**", expanded=not st.session_state["initialize
             st.write("A connection is initialized as")
             st.code(
                 f"""
-                st_supabase = st.connection(
-                    name="supabase_connection", type=SupabaseConnection, {ttl=}
-                    )
-                """,
+st_supabase = st.connection(
+    name="supabase_connection", type=SupabaseConnection, {ttl=}
+)
+""",
                 wrap_lines=True,
             )
 
@@ -197,14 +197,14 @@ with st.expander("**Select project**", expanded=not st.session_state["initialize
                 st.write("A connection is initialized as")
                 st.code(
                     f"""
-                    st_supabase = st.connection(
-                        name="supabase_connection", 
-                        type=SupabaseConnection, 
-                        {ttl=},
-                        url=url, 
-                        key=key, 
-                    )
-                    """,
+st_supabase = st.connection(
+    name="supabase_connection", 
+    type=SupabaseConnection, 
+    {ttl=},
+    url=url, 
+    key=key, 
+)
+""",
                     wrap_lines=True,
                 )
 
@@ -401,10 +401,18 @@ if st.session_state["initialized"]:
                 )
                 overwrite = "true" if rcol.checkbox("Overwrite if exists?") else "false"
 
-                constructed_storage_query = f"""
-                st_supabase.{operation}("{bucket_id}", {source=}, file={file}, destination_path="{destination_path}", {overwrite=})
-                # `UploadedFile` is the `BytesIO` object returned by `st.file_uploader()`
-                """
+                constructed_storage_query = (
+                    f"""
+st_supabase.{operation}(
+    "{bucket_id}", 
+    {source=}, 
+    file={file}, 
+    destination_path="{destination_path}", 
+    {overwrite=},
+)
+# `UploadedFile` is the `BytesIO` object returned by `st.file_uploader()`
+""",
+                )
             else:
                 file = rcol.text_input(
                     "Source path",
@@ -418,8 +426,14 @@ if st.session_state["initialized"]:
                 )
                 overwrite = "true" if rcol.checkbox("Overwrite if exists?") else "false"
                 constructed_storage_query = f"""
-                st_supabase.{operation}("{bucket_id}", {source=}, {file=}, destination_path="{destination_path}", {overwrite=})
-                """
+st_supabase.{operation}(
+    "{bucket_id}", 
+    {source=}, 
+    {file=}, 
+    destination_path="{destination_path}", 
+    {overwrite=},
+)
+"""
             st.session_state["storage_disabled"] = bool(not all([bucket_id, file]))
         elif operation == "list_buckets":
             ttl = st.text_input(
@@ -446,9 +460,13 @@ if st.session_state["initialized"]:
             )
             ttl = None if ttl == "" else ttl
 
-            constructed_storage_query = (
-                f"""st_supabase.{operation}("{bucket_id}", {source_path=}, {ttl=})"""
-            )
+            constructed_storage_query = f"""
+st_supabase.{operation}(
+    "{bucket_id}", 
+    {source_path=}, 
+    {ttl=},
+)
+"""
             st.session_state["storage_disabled"] = bool(not all([bucket_id, source_path]))
 
         elif operation == "move":
@@ -461,9 +479,13 @@ if st.session_state["initialized"]:
                 placeholder="/folder/subFolder/file.txt",
                 help="Path will be created if it does not exist",
             )
-            constructed_storage_query = (
-                f"""st_supabase.{operation}("{bucket_id}", {from_path=}, {to_path=})"""
-            )
+            constructed_storage_query = f"""
+st_supabase.{operation}(
+    "{bucket_id}", 
+    {from_path=}, 
+    {to_path=},
+)
+"""
 
             st.session_state["storage_disabled"] = bool(not all([bucket_id, from_path, to_path]))
         elif operation == "remove":
@@ -472,7 +494,12 @@ if st.session_state["initialized"]:
                 placeholder="""["image.png","/folder/subFolder/file.txt"]""",
                 help="Enter as a list",
             )
-            constructed_storage_query = f"""st_supabase.{operation}("{bucket_id}", paths={paths})"""
+            constructed_storage_query = f"""
+st_supabase.{operation}(
+    "{bucket_id}", 
+    paths={paths},
+)
+"""
 
             st.session_state["storage_disabled"] = bool(not all([bucket_id, paths]))
         elif operation == "list_objects":
@@ -516,7 +543,17 @@ if st.session_state["initialized"]:
                 horizontal=True,
             )
 
-            constructed_storage_query = f"""st_supabase.{operation}("{bucket_id}", {path=}, {limit=}, {offset=}, {sortby=}, {order=}, {ttl=})"""
+            constructed_storage_query = f"""
+st_supabase.{operation}(
+    "{bucket_id}", 
+    {path=}, 
+    {limit=}, 
+    {offset=}, 
+    {sortby=}, 
+    {order=}, 
+    {ttl=},
+)
+"""
 
             st.session_state["storage_disabled"] = not bool(bucket_id)
 
@@ -534,9 +571,14 @@ if st.session_state["initialized"]:
             )
             ttl = None if ttl == "" else ttl
 
-            constructed_storage_query = (
-                f"""st_supabase.get_public_url("{bucket_id}",{filepath=}, {ttl=})"""
-            )
+            constructed_storage_query = f"""
+st_supabase.get_public_url(
+    "{bucket_id}",
+    {filepath=},
+    {ttl=},
+)
+"""
+
             st.session_state["storage_disabled"] = bool(not all([bucket_id, filepath]))
 
         elif operation == "create_signed_urls":
@@ -552,9 +594,13 @@ if st.session_state["initialized"]:
                 value=3600,
             )
 
-            constructed_storage_query = (
-                f"""st_supabase.create_signed_urls("{bucket_id}",paths={paths}, {expires_in=})"""
-            )
+            constructed_storage_query = f"""
+st_supabase.create_signed_urls(
+    "{bucket_id}",
+    paths={paths},
+    {expires_in=},
+)
+"""
             st.session_state["storage_disabled"] = bool(not all([bucket_id, paths, expires_in]))
 
         elif operation == "create_signed_upload_url":
@@ -562,9 +608,12 @@ if st.session_state["initialized"]:
                 "Enter the file path",
                 placeholder="/folder/subFolder/image.jpg",
             )
-            constructed_storage_query = (
-                f"""st_supabase.create_signed_upload_url("{bucket_id}",{path=})"""
-            )
+            constructed_storage_query = f"""
+st_supabase.create_signed_upload_url(
+    "{bucket_id}",
+    {path=},
+)
+"""
             st.session_state["storage_disabled"] = bool(not all([bucket_id, path]))
 
         elif operation == "upload_to_signed_url":
@@ -589,9 +638,16 @@ if st.session_state["initialized"]:
                 file = rcol.file_uploader("Choose a file")
 
                 constructed_storage_query = f"""
-                st_supabase.{operation}("{bucket_id}", {source=}, {path=}, token="***", file={file}, {overwrite=})
-                # `UploadedFile` is the `BytesIO` object returned by `st.file_uploader()`
-                """
+st_supabase.{operation}(
+        "{bucket_id}", 
+        {source=}, 
+        {path=}, 
+        token="***", 
+        file={file}, 
+        {overwrite=},
+)
+# `UploadedFile` is the `BytesIO` object returned by `st.file_uploader()`
+"""
             elif source == "hosted":
                 file = rcol.text_input(
                     "Source path",
@@ -599,8 +655,15 @@ if st.session_state["initialized"]:
                     help="This is the path of the file on the Streamlit hosted filesystem",
                 )
                 constructed_storage_query = f"""
-                st_supabase.{operation}("{bucket_id}", {source=}, {path=}, token="***", {file=}, {overwrite=})
-                """
+st_supabase.{operation}(
+    "{bucket_id}", 
+    {source=}, 
+    {path=}, 
+    token="***", 
+    {file=}, 
+    {overwrite=},
+)
+"""
             st.session_state["storage_disabled"] = bool(not all([bucket_id, token, path]))
 
         st.write("**Constructed code**")
@@ -660,7 +723,6 @@ if st.session_state["initialized"]:
                         path,
                         token,
                         file,
-                        overwrite,
                     )
                 else:
                     response = eval(constructed_storage_query)
@@ -732,17 +794,16 @@ if st.session_state["initialized"]:
                         st.write("Path")
                         st.code(response["path"], wrap_lines=True)
                     elif operation == "upload_to_signed_url":
-                        if response["Key"] == f"{bucket_id}/{path.lstrip('/')}":
-                            try:
-                                st.success(
-                                    f"Uploaded **{file.name}** to **{response['Key']}**",
-                                    icon="✅",
-                                )
-                            except AttributeError:
-                                st.success(
-                                    f"Uploaded **{file}** to **{response['Key']}**",
-                                    icon="✅",
-                                )
+                        try:
+                            st.success(
+                                f"Uploaded **{file.name}** to **{response['full_path']}**",
+                                icon="✅",
+                            )
+                        except AttributeError:
+                            st.success(
+                                f"Uploaded **{file}** to **{response['full_path']}**",
+                                icon="✅",
+                            )
                     else:
                         st.write(response)
             except Exception as e:


### PR DESCRIPTION
## Summary by Sourcery

Bump version to 2.1.3 and fix path issues in signed URL creation and uploads by sanitizing inputs, rejecting invalid paths, and delegating to Supabase client methods. Streamline downloads to return in-memory data with correct MIME types. Standardize parameters and enhance exception handling. Refresh demo app code formatting and success messages. Expand README with detailed quickstart and installation guidance.

Bug Fixes:
- Normalize and validate object paths by stripping leading slashes and rejecting empty values in signed URL and upload URL methods
- Streamline download method to return bytes directly and handle MIME type fallback
- Fix demo app success messages to display full_path instead of Key

Enhancements:
- Refactor create_signed_urls, create_signed_upload_url, and upload_to_signed_url to use Supabase client’s built-in methods and unify error handling
- Improve upload_to_signed_url to support both local and hosted sources with content-type inference and payload handling
- Standardize parameter types and names (e.g., file_size_limit as int, sortby) and update docstrings for clarity
- Refactor demo app code snippets to consistently use multiline strings for constructed storage queries

Documentation:
- Update README with a table of contents, expanded quickstart steps, installation instructions, secrets configuration, and richer usage examples